### PR TITLE
Fix reference to insecure image

### DIFF
--- a/assets/style.scss.liquid
+++ b/assets/style.scss.liquid
@@ -249,7 +249,7 @@ input[type="submit"].quiet:hover {
 	opacity: 0.5;
 	left: 10px;
 	top: 6px;
-	background-image: url(http://cdn.shopify.com/s/files/1/0713/7997/t/2/assets/icon-shopping-basket.svg);
+	background-image: url(//cdn.shopify.com/s/files/1/0713/7997/t/2/assets/icon-shopping-basket.svg);
 	background-size: 18px 18px;
 	background-repeat: no-repeat;
 }


### PR DESCRIPTION
Fix reference to insecure shopping basket image which is causing
browser security warnings. Use protocol relative URL instead.
